### PR TITLE
feat: support for pull request events

### DIFF
--- a/.github/relabel.yml
+++ b/.github/relabel.yml
@@ -1,3 +1,6 @@
-requiredLabels:
+issues:
+  - missingLabel: needs-type
+    regex: type:.*
+pulls:
   - missingLabel: needs-type
     regex: type:.*

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ pulls:
     regex: type:.*
 ```
 
+### Backwards compatibility
+Previous version of the bot will still work with current version, as the schema for the configuration file does not change the structure. So it's possible to upgrade and keep old configuration:
+
+```yaml
+# The old format matches the new one, using a different name
+requiredLabels:
+  - missingLabel: needs-area
+    regex: area:.*
+  - missingLabel: needs-type
+    regex: type:.*
+```
+
 ## Contribute
 
 If you have suggestions for how this bot could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status][travis-status]][travis-url]
 
 A [Probot](https://probot.github.io) bot to make sure that a given label is added
-to specific issues when all other labels do not match a regex.
+to specific issues and pull requests when all other labels do not match a regex.
 
 ## Setup
 
@@ -14,11 +14,17 @@ If the config is empty or doesn't exist, the bot will not run.
 
 ```yml
 # This example configuration will add the `needs-area` and `needs-type` labels
-# to any new issues that do not have labels matching `area:.*` or `type:.*`.
-# Once the issue has the `area:.....` label added the `needs-area` label will be 
-# removed from the issue.
-requiredLabels:
-    # The missing label which will be added if the regex doesn't match any other labels
+# to any new issue and pull request that do not have labels matching `area:.*` or `type:.*`.
+# Once the issue or the pull request has the `area:.....` label added the `needs-area` label will be 
+# removed from the issue or pull request.
+issues:
+    # The missing label which will be added to issues if the regex doesn't match any other labels
+  - missingLabel: needs-area
+    regex: area:.*
+  - missingLabel: needs-type
+    regex: type:.*
+pulls:
+    # The missing label which will be added to pull requests if the regex doesn't match any other labels
   - missingLabel: needs-area
     regex: area:.*
   - missingLabel: needs-type

--- a/src/__test__/fakecontext.ts
+++ b/src/__test__/fakecontext.ts
@@ -16,7 +16,7 @@ export class FakeContext extends Context<any> {
     this.payload = payload;
     this.github = github;
     this.config = configMethod;
-    this.name = "test";
+    this.name = github.event;
     this.id = "test";
     this.log = {
       child: (x: any) => {

--- a/src/__test__/fakegithub.ts
+++ b/src/__test__/fakegithub.ts
@@ -5,11 +5,13 @@ export class FakeGithub {
   public labelsAdded: string[];
   public labelsRemoved: string[];
   public issues: object;
+  public event: string;
 
-  constructor(initialLabels: string[]) {
+  constructor(initialLabels: string[], event: string = "issues") {
     this.labels = initialLabels;
     this.labelsAdded = [];
     this.labelsRemoved = [];
     this.issues = new FakeIssueApi(this);
+    this.event = event;
   }
 }

--- a/src/__test__/handler.pulls.test.ts
+++ b/src/__test__/handler.pulls.test.ts
@@ -1,0 +1,80 @@
+import { handle } from "../handler";
+import { FakeContext } from "./fakecontext";
+import { FakeGithub } from "./fakegithub";
+
+it("adds needs-area label to pull request when a label doesn't match area:.* on the pull request", () => {
+  expect.assertions(1);
+  const github = new FakeGithub([], "pull_request");
+  const context = new FakeContext({ pull_request: { labels: [] } }, github, {});
+  return handle(
+    context,
+    [{ missingLabel: "needs-area", regex: "area:.*" }],
+    1
+  ).then(resp => {
+    expect(github.labels).toContain("needs-area");
+  });
+});
+
+it("doesn't add needs-area label to the pull request when needs-area label is already on the pull request", () => {
+  expect.assertions(2);
+  const github = new FakeGithub(["needs-area"], "pull_request");
+  const context = new FakeContext({ pull_request: { labels: [] } }, github, {});
+  return handle(
+    context,
+    [{ missingLabel: "needs-area", regex: "area:.*" }],
+    1
+  ).then(resp => {
+    expect(github.labels).toEqual(["needs-area"]);
+    expect(github.labelsAdded).toEqual([]);
+  });
+});
+
+it("doesn't add needs-area label to the pull request when a label matching area/.* is on the pull request", () => {
+  expect.assertions(2);
+  const github = new FakeGithub(["area:test"], "pull_request");
+  const context = new FakeContext({ pull_request: { labels: [] } }, github, {});
+  return handle(
+    context,
+    [{ missingLabel: "needs-area", regex: "area:.*" }],
+    1
+  ).then(resp => {
+    expect(github.labels).toEqual(["area:test"]);
+    expect(github.labelsAdded).toEqual([]);
+  });
+});
+
+it("removes needs-area label on the pull request when a label matching area/.* exists on the pull request", () => {
+  expect.assertions(2);
+  const github = new FakeGithub(["area:test", "needs-area"], "pull_request");
+  const context = new FakeContext(
+    { pull_request: { labels: [], label: "area:test" } },
+    github,
+    {}
+  );
+  return handle(
+    context,
+    [{ missingLabel: "needs-area", regex: "area:.*" }],
+    1
+  ).then(resp => {
+    expect(github.labels).toEqual(["area:test"]);
+    expect(github.labelsRemoved).toEqual(["needs-area"]);
+  });
+});
+
+it("doesn't remove needs-area label on then pull request when a label doesn't match area/.* on the pull request", () => {
+  expect.assertions(2);
+  const github = new FakeGithub(["test:test", "needs-area"], "pull_request");
+  const context = new FakeContext(
+    { pull_request: { labels: [], label: "test:test" } },
+    github,
+    {}
+  );
+  return handle(
+    context,
+    [{ missingLabel: "needs-area", regex: "area:.*" }],
+    1
+  ).then(resp => {
+    expect(github.labels).toEqual(["test:test", "needs-area"]);
+    expect(github.labelsRemoved).toEqual([]);
+  });
+});

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -11,7 +11,13 @@ export async function handle(
   requiredLabels: ILabelMatch[],
   waitTimeMs: number
 ): Promise<void> {
-  let labels: ILabel[] = context.payload.issue.labels;
+  let labels: ILabel[];
+  if ("pull_request" === context.event) {
+    labels = context.payload.pull_request.labels;
+  } else {
+    labels = context.payload.issue.labels;
+  }
+
   const issueNumber = context.issue().number;
   const owner = context.issue().owner;
   const repo = context.issue().repo;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ module.exports = async (app: Application) => {
     if ("pull_request" === context.event) {
       eventType = config.pulls;
     }
+    if (!eventType) {
+      eventType = config.requiredLabels;
+    }
 
     if (eventType) {
       logger.debug("Config exists");

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ module.exports = async (app: Application) => {
     "issues.opened",
     "issues.reopened",
     "issues.labeled",
-    "issues.unlabeled"
+    "issues.unlabeled",
+    "pull_request.opened",
+    "pull_request.reopened",
+    "pull_request.labeled",
+    "pull_request.unlabeled"
   ];
   const configManager = new ConfigManager<IConfig>("relabel.yml", {}, schema);
   app.log.info("probot-require-label loaded");
@@ -29,10 +33,16 @@ module.exports = async (app: Application) => {
       logger.error(err);
       return {} as IConfig;
     });
-    if (config.requiredLabels) {
+
+    let eventType = config.issues;
+    if ("pull_request" === context.event) {
+      eventType = config.pulls;
+    }
+
+    if (eventType) {
       logger.debug("Config exists");
       logger.debug(config);
-      await handle(context, config.requiredLabels!, 30000).catch(err => {
+      await handle(context, eventType!, 30000).catch(err => {
         logger.error(err);
       });
       logger.debug("Handled");

--- a/src/models.ts
+++ b/src/models.ts
@@ -8,6 +8,8 @@ export interface ILabelMatch {
 export interface IConfig {
   issues?: ILabelMatch[];
   pulls?: ILabelMatch[];
+  // fallback supoprting backwards compatibility
+  requiredLabels?: ILabelMatch[];
 }
 
 //
@@ -29,6 +31,12 @@ export const schema = Joi.object().keys({
     })
   ),
   pulls: Joi.array().items(
+    Joi.object().keys({
+      missingLabel: Joi.string(),
+      regex: Joi.string()
+    })
+  ),
+  requiredLabels: Joi.array().items(
     Joi.object().keys({
       missingLabel: Joi.string(),
       regex: Joi.string()

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,17 +6,29 @@ export interface ILabelMatch {
 }
 
 export interface IConfig {
-  requiredLabels?: ILabelMatch[];
+  issues?: ILabelMatch[];
+  pulls?: ILabelMatch[];
 }
 
 //
-// requiredLabels:
+// issues:
+// - missingLabel: needs-area
+//   regex: area:.*
+// - missingLabel: needs-type
+//   reqex: type:.*
+// pulls:
 // - missingLabel: needs-area
 //   regex: area:.*
 // - missingLabel: needs-type
 //   reqex: type:.*
 export const schema = Joi.object().keys({
-  requiredLabels: Joi.array().items(
+  issues: Joi.array().items(
+    Joi.object().keys({
+      missingLabel: Joi.string(),
+      regex: Joi.string()
+    })
+  ),
+  pulls: Joi.array().items(
     Joi.object().keys({
       missingLabel: Joi.string(),
       regex: Joi.string()


### PR DESCRIPTION
## What does this PR do?
It add support for using this bot with pull requests too, using same configuration file as in the [`probot-labeler`](https://github.com/lswith/probot-labeler) bot:

```yaml
issues:
  - missingLabel: needs-type
    regex: type:.*
pulls:
  - missingLabel: needs-type
    regex: type:.*

```

As this change modifies the schema of the configuration file, I'd suggest bumping the project with a major.

On the other hand, as the structure is almost the same, I'm providing a fallback for previous versions of the bot, so no need of recconfiguring it everywhere.


## Why is it important?
The functionality of this bot is great, so why not adding that behavior to PR? :)

## Related issues
- Closes #8 